### PR TITLE
Add operator-specific quick add for activities

### DIFF
--- a/index.html
+++ b/index.html
@@ -317,7 +317,10 @@
             roles={roles}
             currentUser={currentUser}
             onBack={() => { setSelectedFlow(null); setSelectedProject(null); setView('dashboard'); }}
-            onCreateActivity={() => setShowModal('createActivity')}
+            onCreateActivity={(operatorId) => {
+              setModalData(operatorId ? { operatorId } : {});
+              setShowModal('createActivity');
+            }}
             onEditActivity={(aid) => { setModalData({ projectId: selectedProject.id, flowId: selectedFlow.id, activityId: aid }); setShowModal('editActivity'); }}
             onDeleteActivity={(aid) => { setModalData({ projectId: selectedProject.id, flowId: selectedFlow.id, activityId: aid }); setShowModal('deleteActivity'); }}
             onClaimActivity={(aid) => { setModalData({ projectId: selectedProject.id, flowId: selectedFlow.id, activityId: aid }); setShowModal('claimActivity'); }}
@@ -335,7 +338,7 @@
           {showModal === 'createProject' && <CreateProjectModal onClose={() => setShowModal(null)} onCreate={(name, users) => { createProject(name, users, currentUser); setShowModal(null); }} />}
           {showModal === 'createFlow' && selectedProject && <CreateFlowModal onClose={() => setShowModal(null)} onCreate={(name, del, desc) => { createFlow(selectedProject.id, name, del, desc); setShowModal(null); }} />}
           {showModal === 'manageUsers' && selectedProject && <ManageUsersModal project={selectedProject} onClose={() => setShowModal(null)} onAddUser={(name) => addUserToProject(selectedProject.id, name)} onRemoveUser={(uid) => removeUserFromProject(selectedProject.id, uid)} />}
-          {showModal === 'createActivity' && selectedProject && selectedFlow && <CreateActivityModal project={selectedProject} flow={selectedFlow} roles={roles} onClose={() => setShowModal(null)} onCreate={(title, roleId, deliverable) => { createActivity(selectedProject.id, selectedFlow.id, title, roleId, deliverable); setShowModal(null); }} onCreateRole={createRole} onUpdateRole={updateRole} />}
+          {showModal === 'createActivity' && selectedProject && selectedFlow && <CreateActivityModal project={selectedProject} flow={selectedFlow} roles={roles} initialOperatorId={modalData.operatorId} onClose={() => { setShowModal(null); setModalData({}); }} onCreate={(title, roleId, deliverable) => { createActivity(selectedProject.id, selectedFlow.id, title, roleId, deliverable); setShowModal(null); setModalData({}); }} onCreateRole={createRole} onUpdateRole={updateRole} />}
           {showModal === 'editActivity' && selectedFlow && <EditActivityModal project={selectedProject} activity={selectedFlow.activities.find(a => a.id === modalData.activityId)} roles={roles} onClose={() => { setShowModal(null); setModalData({}); }} onUpdate={(updates) => { updateActivity(modalData.projectId, modalData.flowId, modalData.activityId, updates); setShowModal(null); setModalData({}); }} onCreateRole={createRole} onUpdateRole={updateRole} />}
           {showModal === 'deleteActivity' && selectedFlow && <DeleteActivityModal activity={selectedFlow.activities.find(a => a.id === modalData.activityId)} onClose={() => { setShowModal(null); setModalData({}); }} onDelete={() => { deleteActivity(modalData.projectId, modalData.flowId, modalData.activityId); setShowModal(null); setModalData({}); }} />}
           {showModal === 'claimActivity' && selectedFlow && <ClaimActivityModal activity={selectedFlow.activities.find(a => a.id === modalData.activityId)} roles={roles} project={selectedProject} onClose={() => { setShowModal(null); setModalData({}); }} onClaim={(priority) => { claimActivity(modalData.projectId, modalData.flowId, modalData.activityId, priority); setShowModal(null); setModalData({}); }} />}
@@ -625,7 +628,7 @@
                   <h1 className="text-2xl font-bold mb-2">{flow.name}</h1>
                   {flow.description && <p className="text-gray-300">{flow.description}</p>}
                 </div>
-                <button onClick={onCreateActivity} className="flex items-center gap-2 bg-blue-600 hover:bg-blue-700 px-4 py-2 rounded-lg font-medium transition-colors">
+                <button onClick={() => onCreateActivity()} className="flex items-center gap-2 bg-blue-600 hover:bg-blue-700 px-4 py-2 rounded-lg font-medium transition-colors">
                   <PlusIcon className="w-4 h-4" />New Activity
                 </button>
               </div>
@@ -644,7 +647,12 @@
                 <div key={operator.id} className="bg-gray-900 border border-gray-800 rounded-lg p-4">
                   <div className="mb-4">
                     <div className="flex items-center justify-between mb-1">
-                      <h3 className="font-semibold">{operator.seq}. {operator.name}</h3>
+                      <div className="flex items-center gap-2">
+                        <h3 className="font-semibold">{operator.seq}. {operator.name}</h3>
+                        <button onClick={() => onCreateActivity(operator.id)} className="p-1 rounded bg-gray-800/60 hover:bg-gray-700 transition-colors" title="Add activity">
+                          <PlusIcon className="w-3.5 h-3.5" />
+                        </button>
+                      </div>
                       <span className="text-xs bg-gray-800 px-2 py-1 rounded">{groupedActivities[operator.id]?.length || 0}</span>
                     </div>
                     <p className="text-xs text-gray-300">{operator.desc}</p>
@@ -812,14 +820,27 @@
       );
     }
 
-    function CreateActivityModal({ project, flow, roles, onClose, onCreate, onCreateRole, onUpdateRole }) {
+    function CreateActivityModal({ project, flow, roles, onClose, onCreate, onCreateRole, onUpdateRole, initialOperatorId }) {
       const [step, setStep] = useState('role');
       const [title, setTitle] = useState('');
       const [selectedRole, setSelectedRole] = useState('');
       const [newRoleName, setNewRoleName] = useState('');
-      const [selectedOperator, setSelectedOperator] = useState('');
+      const [selectedOperator, setSelectedOperator] = useState(initialOperatorId || '');
       const [selectedUserIds, setSelectedUserIds] = useState([]);
       const [deliverable, setDeliverable] = useState('');
+
+      useEffect(() => {
+        setSelectedOperator(initialOperatorId || '');
+        setSelectedRole('');
+        setStep('role');
+        setTitle('');
+        setDeliverable('');
+        setNewRoleName('');
+        setSelectedUserIds([]);
+      }, [initialOperatorId, project.id, flow.id]);
+
+      const availableRoles = initialOperatorId ? roles.filter(r => r.operatorType === initialOperatorId) : roles;
+      const operatorChoices = initialOperatorId ? OPERATORS.filter(op => op.id === initialOperatorId) : OPERATORS;
 
       const handleCreateRole = () => {
         if (newRoleName && selectedOperator) {
@@ -839,15 +860,15 @@
             {step === 'role' ? (
               <>
                 <div className="bg-blue-900/30 border border-blue-700/50 rounded p-4 mb-4"><p className="text-sm text-gray-100">Each activity needs a role (who does it) and operator type (what kind of work).</p></div>
-                {roles.length > 0 && (
+                {availableRoles.length > 0 && (
                   <>
-                    <div><label className="block text-sm text-gray-200 mb-2">Select existing role</label><select value={selectedRole} onChange={(e) => setSelectedRole(e.target.value)} className="w-full bg-gray-800 border border-gray-700 rounded px-4 py-2 text-gray-100"><option value="">Choose...</option>{roles.map(r => { const op = OPERATORS.find(o => o.id === r.operatorType); return <option key={r.id} value={r.id}>{r.name} ({op?.name})</option>; })}</select></div>
+                    <div><label className="block text-sm text-gray-200 mb-2">Select existing role</label><select value={selectedRole} onChange={(e) => setSelectedRole(e.target.value)} className="w-full bg-gray-800 border border-gray-700 rounded px-4 py-2 text-gray-100"><option value="">Choose...</option>{availableRoles.map(r => { const op = OPERATORS.find(o => o.id === r.operatorType); return <option key={r.id} value={r.id}>{r.name} ({op?.name})</option>; })}</select></div>
                     {selectedRole && <button onClick={() => setStep('activity')} className="w-full bg-blue-600 hover:bg-blue-700 py-2 rounded transition-colors">Continue</button>}
                     <div className="relative"><div className="absolute inset-0 flex items-center"><div className="w-full border-t border-gray-700"></div></div><div className="relative flex justify-center text-sm"><span className="px-2 bg-gray-900 text-gray-300">or create new role</span></div></div>
                   </>
                 )}
                 <div><label className="block text-sm text-gray-200 mb-2">New role name</label><input type="text" value={newRoleName} onChange={(e) => setNewRoleName(e.target.value)} placeholder="e.g., Content Writer" className="w-full bg-gray-800 border border-gray-700 rounded px-4 py-2 text-gray-100 placeholder-gray-400" /></div>
-                <div><label className="block text-sm text-gray-200 mb-2">Select operator type</label><div className="grid grid-cols-3 gap-2">{OPERATORS.map(op => <button key={op.id} onClick={() => setSelectedOperator(op.id)} className={`p-3 border rounded text-left transition-colors ${selectedOperator === op.id ? 'border-blue-500 bg-blue-500/20' : 'border-gray-700 hover:border-gray-600'}`}><div className="font-medium text-sm">{op.seq}. {op.name}</div><div className="text-xs text-gray-300 mt-1">{op.desc}</div></button>)}</div></div>
+                <div><label className="block text-sm text-gray-200 mb-2">Select operator type</label><div className="grid grid-cols-3 gap-2">{operatorChoices.map(op => <button key={op.id} onClick={() => setSelectedOperator(op.id)} className={`p-3 border rounded text-left transition-colors ${selectedOperator === op.id ? 'border-blue-500 bg-blue-500/20' : 'border-gray-700 hover:border-gray-600'}`}><div className="font-medium text-sm">{op.seq}. {op.name}</div><div className="text-xs text-gray-300 mt-1">{op.desc}</div></button>)}</div></div>
                 <div><label className="block text-sm text-gray-200 mb-2">Assign users to this role</label><div className="space-y-2">{project.users.map(user => <label key={user.id} className="flex items-center gap-3 p-3 bg-gray-800 border border-gray-700 rounded cursor-pointer hover:border-gray-600"><input type="checkbox" checked={selectedUserIds.includes(user.id)} onChange={() => toggleUser(user.id)} /><span className="text-sm text-gray-100">{user.name}</span></label>)}</div></div>
                 <div className="flex gap-3 pt-4"><button onClick={onClose} className="flex-1 bg-gray-700 hover:bg-gray-600 py-2 rounded transition-colors">Cancel</button><button onClick={handleCreateRole} disabled={!newRoleName || !selectedOperator} className="flex-1 bg-green-600 hover:bg-green-700 disabled:bg-gray-700 py-2 rounded transition-colors">Create Role & Continue</button></div>
               </>


### PR DESCRIPTION
## Summary
- add per-operator quick-add buttons in the activities view to open the create activity modal scoped to that role type
- prefilter existing roles and operator choices in the create activity flow when launched from a role card and reset modal state between launches
- clear modal metadata after closing or creating activities to avoid leaking operator filters

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_b_68e5f59e5c408332be7bdf3b0ffa345c