### PR TITLE
Rename Connector operator to Compiler

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@
     const OPERATORS = [
       { id: 'starter', name: 'Starter', desc: 'Designs & initiates work', seq: 1, canRequestRevision: false },
       { id: 'doer', name: 'Doer', desc: 'Produces artifacts & outputs', seq: 2, canRequestRevision: false },
-      { id: 'connector', name: 'Connector', desc: 'Links work across contexts', seq: 3, canRequestRevision: false },
+      { id: 'compiler', name: 'Compiler', desc: 'Packages work into reviewable form', seq: 3, canRequestRevision: false },
       { id: 'reviewer', name: 'Reviewer', desc: 'Evaluates & segments quality', seq: 4, canRequestRevision: true },
       { id: 'approver', name: 'Approver', desc: 'Alters state with authority', seq: 5, canRequestRevision: true },
       { id: 'documenter', name: 'Documenter', desc: 'Records & formalizes', seq: 6, canRequestRevision: false },

--- a/manual.md
+++ b/manual.md
@@ -35,7 +35,7 @@ Every activity in Event Operator is assigned to one of nine operator types. Thes
 
 1. **Starter** - Designs and initiates work
 2. **Doer** - Produces artifacts and outputs
-3. **Connector** - Links work across contexts
+3. **Compiler** - Packages work into reviewable form
 4. **Reviewer** - Evaluates and segments quality
 5. **Approver** - Alters state with authority
 6. **Documenter** - Records and formalizes
@@ -516,7 +516,7 @@ Approver: "Approve design" ──┬──> Doer: "Build landing page"
 **Example:**
 ```
 Doer: "Write section 1" ──┐
-Doer: "Write section 2" ──┼──> Connector: "Integrate all sections"
+Doer: "Write section 2" ──┼──> Compiler: "Integrate all sections"
 Doer: "Write section 3" ──┘
 ```
 
@@ -592,7 +592,7 @@ The title should make it obvious what needs to be done.
 
 The nine operator types help you think about coordination holistically:
 - Starting work (Starter)
-- Doing work (Doer, Connector)
+- Doing work (Doer, Compiler)
 - Quality gates (Reviewer, Approver)
 - Recording (Documenter)
 - Distribution (Convener, Steward)


### PR DESCRIPTION
## Summary
- rename the Connector operator to Compiler in the application UI with the updated description
- refresh the user manual to reflect the Compiler terminology and workflow references

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68e5f7c1c43c83328e8f2f90f212c8d7