### PR TITLE
Refactor activity view around stage metadata

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,6 +27,65 @@
       { id: 'coordinator', name: 'Coordinator', desc: 'Orchestrates next cycle', seq: 9, canRequestRevision: false }
     ];
 
+    const DEFAULT_STAGE_BLUEPRINT = OPERATORS.map((op, index) => ({
+      key: op.id,
+      name: op.name,
+      description: op.desc,
+      order: index,
+      supportsRevision: op.canRequestRevision
+    }));
+
+    function getStageIdentity(stage) {
+      return stage?.id || stage?.key || stage?.name;
+    }
+
+    function createDefaultStages() {
+      const timestamp = Date.now();
+      return DEFAULT_STAGE_BLUEPRINT.map((stage, idx) => ({
+        id: `stage-${timestamp}-${idx}`,
+        key: stage.key,
+        operatorKey: stage.key,
+        name: stage.name,
+        description: stage.description,
+        order: idx,
+        roleId: null,
+        supportsRevision: stage.supportsRevision,
+        conditions: '',
+        skipped: false
+      }));
+    }
+
+    function getOrderedStages(flow) {
+      const stages = Array.isArray(flow?.stages) && flow.stages.length > 0
+        ? flow.stages
+        : DEFAULT_STAGE_BLUEPRINT.map((stage, idx) => ({
+            key: stage.key,
+            operatorKey: stage.key,
+            name: stage.name,
+            description: stage.description,
+            order: idx,
+            roleId: null,
+            supportsRevision: stage.supportsRevision,
+            conditions: '',
+            skipped: false
+          }));
+
+      return [...stages]
+        .map((stage, idx) => ({
+          ...stage,
+          order: stage.order ?? idx,
+          operatorKey: stage.operatorKey || stage.key,
+          uid: getStageIdentity(stage)
+        }))
+        .sort((a, b) => (a.order ?? 0) - (b.order ?? 0));
+    }
+
+    function findStageForRole(flow, role) {
+      if (!role) return null;
+      const orderedStages = getOrderedStages(flow);
+      return orderedStages.find(stage => stage.operatorKey === role.operatorType || stage.key === role.operatorType) || null;
+    }
+
     // Icons
     function PlusIcon(props) {
       return <svg {...props} fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}><path strokeLinecap="round" strokeLinejoin="round" d="M12 4v16m8-8H4" /></svg>;
@@ -50,7 +109,7 @@
       return <svg {...props} fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}><path strokeLinecap="round" strokeLinejoin="round" d="M8 10h.01M12 10h.01M16 10h.01M21 12c0 1.657-1.79 3-4 3-.295 0-.582-.021-.859-.061-.284 1.193-1.355 2.06-2.641 2.06-.358 0-.703-.065-1.019-.184-.44.498-1.086.814-1.781.814-.732 0-1.392-.347-1.829-.888-.51.355-1.137.558-1.812.558-1.648 0-2.985-1.343-2.985-3 0-.333.054-.654.153-.954C3.1 12.715 2 11.477 2 10c0-1.657 1.79-3 4-3h11c2.21 0 4 1.343 4 3z" /></svg>;
     }
 
-    function ActivityDetailPanel({ activity, role, operator, dependencies, project, currentUser, onClose, onEdit, onDelete, onClaim, onUnclaim, onComplete, onWire, onRequestRevision, onAddComment, onAddAttachment, onRemoveAttachment }) {
+    function ActivityDetailPanel({ activity, role, stage, nextStage, stageMap, dependencies, project, currentUser, onClose, onEdit, onDelete, onClaim, onUnclaim, onAdvanceStage, onSkipStage, onComplete, onWire, onRequestRevision, onAddComment, onAddAttachment, onRemoveAttachment }) {
       const [commentText, setCommentText] = useState('');
       const [attachmentName, setAttachmentName] = useState('');
       const [attachmentUrl, setAttachmentUrl] = useState('');
@@ -64,6 +123,10 @@
       const isMine = activity.claimedBy === currentUser;
       const canClaim = activity.state === 'ready' && !activity.claimedBy && role?.userIds.some(uid => project.users.find(u => u.id === uid)?.name === currentUser);
       const canComplete = isMine && activity.state === 'in_progress';
+      const isCompleted = activity.state === 'completed';
+      const canAdvanceStage = !isCompleted;
+      const canSkipStage = !isCompleted && !!nextStage;
+      const stageSupportsRevision = stage?.supportsRevision;
 
       const comments = [...(activity.comments || [])].sort((a, b) => (a.createdAt || 0) - (b.createdAt || 0));
       const history = [...(activity.history || [])].sort((a, b) => (b.timestamp || 0) - (a.timestamp || 0));
@@ -97,10 +160,12 @@
         <div className="flex flex-wrap gap-2">
           {canClaim && <button onClick={() => onClaim(activity.id)} className="bg-blue-600 hover:bg-blue-700 px-3 py-1.5 rounded text-sm">Claim</button>}
           {isMine && !activity.completedAt && <button onClick={() => onUnclaim(activity.id)} className="bg-gray-700 hover:bg-gray-600 px-3 py-1.5 rounded text-sm">Unclaim</button>}
-          {canComplete && <button onClick={() => onComplete(activity.id)} className="bg-green-600 hover:bg-green-700 px-3 py-1.5 rounded text-sm">Complete</button>}
-          {canComplete && operator?.canRequestRevision && dependencies.length > 0 && (
+          {canAdvanceStage && <button onClick={() => onAdvanceStage(activity.id)} className="bg-green-600 hover:bg-green-700 px-3 py-1.5 rounded text-sm">{nextStage ? 'Advance' : 'Finish Stage'}</button>}
+          {canSkipStage && <button onClick={() => onSkipStage(activity.id)} className="bg-yellow-700 hover:bg-yellow-600 px-3 py-1.5 rounded text-sm text-yellow-100">Skip Stage</button>}
+          {stageSupportsRevision && dependencies.length > 0 && !activity.completedAt && (
             <button onClick={() => { const lastDep = dependencies[dependencies.length - 1]; if (lastDep) onRequestRevision(activity.id, lastDep.activity.id); }} className="bg-orange-600 hover:bg-orange-700 px-3 py-1.5 rounded text-sm">Request revision</button>
           )}
+          {canComplete && <button onClick={() => onComplete(activity.id)} className="bg-emerald-600 hover:bg-emerald-700 px-3 py-1.5 rounded text-sm">Complete</button>}
           {!activity.completedAt && <button onClick={() => onWire(activity.id)} className="bg-purple-600 hover:bg-purple-700 px-3 py-1.5 rounded text-sm">Wire</button>}
           {!activity.completedAt && <button onClick={() => onEdit(activity.id)} className="bg-gray-800 hover:bg-gray-700 px-3 py-1.5 rounded text-sm">Edit</button>}
           {!activity.completedAt && <button onClick={() => onDelete(activity.id)} className="bg-red-700 hover:bg-red-800 px-3 py-1.5 rounded text-sm">Delete</button>}
@@ -123,7 +188,16 @@
                 <div className="flex items-start justify-between">
                   <div className="space-y-2 text-sm text-gray-200">
                     {role && <div><span className="text-gray-400">Role:</span> {role.name}</div>}
-                    {operator && <div><span className="text-gray-400">Operator:</span> {operator.name}</div>}
+                    {stage && <div><span className="text-gray-400">Stage:</span> {stage.name}</div>}
+                    {stage?.conditions && <div className="text-xs text-blue-200 bg-blue-900/20 border border-blue-800/30 rounded px-2 py-1">Conditions: {stage.conditions}</div>}
+                    {activity.skippedStages?.length > 0 && (
+                      <div className="text-xs text-yellow-300">Skipped: {activity.skippedStages.map(id => stageMap?.[id]?.name || id).join(', ')}</div>
+                    )}
+                    {nextStage ? (
+                      <div className="text-xs text-gray-400">Next stage: {nextStage.name}</div>
+                    ) : (
+                      <div className="text-xs text-gray-500">Final stage</div>
+                    )}
                     {activity.deliverable && <div><span className="text-gray-400">Deliverable:</span> {activity.deliverable}</div>}
                     {activity.claimedBy && <div><span className="text-gray-400">Claimed by:</span> {activity.claimedBy} {activity.priority && <span className="text-xs bg-blue-900/60 text-blue-200 px-2 py-0.5 ml-2 rounded">{activity.priority}</span>}</div>}
                     <div className="text-xs text-gray-500">Created {formatTimestamp(activity.createdAt)}</div>
@@ -136,6 +210,7 @@
                       {dependencies.map((dep, idx) => (
                         <li key={idx} className="flex items-center gap-2">
                           <ChevronRightIcon className="w-3 h-3 text-gray-500" />
+                          <span className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded bg-gray-800/80 text-[11px] text-gray-300">{stageMap?.[dep.activity.stageId]?.name || dep.activity.stageId || 'Stage'}</span>
                           <span className={dep.activity.completedAt ? 'line-through text-gray-500' : ''}>{dep.activity.title}</span>
                           {dep.edgeType === 'loops' && <span className="text-xs text-orange-400">(revision)</span>}
                         </li>
@@ -337,6 +412,7 @@
             name,
             deliverables,
             description,
+            stages: createDefaultStages(),
             activities: [],
             edges: []
           }]
@@ -345,24 +421,33 @@
 
       const createActivity = (projectId, flowId, title, roleId, deliverable = '') => {
         const timestamp = Date.now();
+        const role = roles.find(r => r.id === roleId);
         setProjects(prev => prev.map(p => p.id === projectId ? {
           ...p,
-          flows: p.flows.map(f => f.id === flowId ? {
-            ...f,
-            activities: [...f.activities, {
-              id: `a-${Date.now()}`,
-              title,
-              roleId,
-              deliverable,
-              claimedBy: null,
-              priority: null,
-              createdAt: timestamp,
-              comments: [],
-              attachments: [],
-              history: [{ id: `h-${timestamp}`, text: `${currentUser || 'Someone'} created this activity`, timestamp }],
-              readBy: {}
-            }]
-          } : f)
+          flows: p.flows.map(f => {
+            if (f.id !== flowId) return f;
+            const orderedStages = getOrderedStages(f);
+            const targetStage = findStageForRole(f, role) || orderedStages[0] || null;
+            const stageId = targetStage ? getStageIdentity(targetStage) : null;
+            return {
+              ...f,
+              activities: [...f.activities, {
+                id: `a-${Date.now()}`,
+                title,
+                roleId,
+                stageId,
+                skippedStages: [],
+                deliverable,
+                claimedBy: null,
+                priority: null,
+                createdAt: timestamp,
+                comments: [],
+                attachments: [],
+                history: [{ id: `h-${timestamp}`, text: `${currentUser || 'Someone'} created this activity`, timestamp }],
+                readBy: {}
+              }]
+            };
+          })
         } : p));
       };
 
@@ -371,7 +456,19 @@
           ...p,
           flows: p.flows.map(f => f.id === flowId ? {
             ...f,
-            activities: f.activities.map(a => a.id === activityId ? { ...a, ...updates } : a)
+            activities: f.activities.map(a => {
+              if (a.id !== activityId) return a;
+              let nextStageId = a.stageId;
+              if (updates.roleId) {
+                const nextRole = roles.find(r => r.id === updates.roleId);
+                const stage = findStageForRole(f, nextRole) || (getOrderedStages(f)[0] || null);
+                if (stage) nextStageId = getStageIdentity(stage);
+              }
+              const merged = { ...a, ...updates };
+              if (nextStageId !== undefined) merged.stageId = nextStageId;
+              if (!merged.skippedStages) merged.skippedStages = a.skippedStages || [];
+              return merged;
+            })
           } : f)
         } : p));
       };
@@ -555,6 +652,7 @@
       const spawnActivity = (projectId, flowId, sourceActivityId, title, roleId, deliverable = '') => {
         const newActivityId = `a-${Date.now()}`;
         const timestamp = Date.now();
+        const role = roles.find(r => r.id === roleId);
         setProjects(prev => prev.map(p => p.id === projectId ? {
           ...p,
           flows: p.flows.map(f => f.id === flowId ? {
@@ -563,6 +661,12 @@
               id: newActivityId,
               title,
               roleId,
+              stageId: (() => {
+                const orderedStages = getOrderedStages(f);
+                const stage = findStageForRole(f, role) || orderedStages[0] || null;
+                return stage ? getStageIdentity(stage) : null;
+              })(),
+              skippedStages: [],
               deliverable,
               claimedBy: null,
               priority: null,
@@ -598,6 +702,8 @@
               id: revisionId,
               title: `${targetActivity.title} (revision)`,
               roleId: targetActivity.roleId,
+              stageId: targetActivity.stageId,
+              skippedStages: [...(targetActivity.skippedStages || [])],
               deliverable: targetActivity.deliverable,
               claimedBy: null,
               priority: null,
@@ -615,6 +721,83 @@
             ]
           } : f)
         } : p));
+      };
+
+      const updateFlowStage = (projectId, flowId, stageId, updater) => {
+        setProjects(prev => prev.map(p => p.id === projectId ? {
+          ...p,
+          flows: p.flows.map(f => {
+            if (f.id !== flowId) return f;
+            const existingStages = Array.isArray(f.stages) && f.stages.length > 0 ? f.stages : createDefaultStages();
+            const updatedStages = existingStages.map(stage => {
+              const identity = getStageIdentity(stage);
+              if (identity !== stageId && stage.key !== stageId) return stage;
+              return { ...stage, ...updater(stage) };
+            });
+            return { ...f, stages: updatedStages };
+          })
+        } : p));
+      };
+
+      const configureStageConditions = (projectId, flowId, stageId, conditions) => {
+        updateFlowStage(projectId, flowId, stageId, () => ({ conditions }));
+      };
+
+      const toggleStageSkip = (projectId, flowId, stageId) => {
+        updateFlowStage(projectId, flowId, stageId, (stage) => ({ skipped: !stage.skipped }));
+      };
+
+      const advanceActivityStage = (projectId, flowId, activityId, { skip = false } = {}) => {
+        const timestamp = Date.now();
+        const actor = currentUser || 'Someone';
+        setProjects(prev => prev.map(p => p.id === projectId ? {
+          ...p,
+          flows: p.flows.map(f => {
+            if (f.id !== flowId) return f;
+            const orderedStages = getOrderedStages(f);
+            return {
+              ...f,
+              activities: f.activities.map(a => {
+                if (a.id !== activityId) return a;
+                const historyEntries = [];
+                const currentStage = orderedStages.find(stage => getStageIdentity(stage) === a.stageId) || orderedStages[0] || null;
+                const currentIndex = currentStage ? orderedStages.findIndex(stage => getStageIdentity(stage) === getStageIdentity(currentStage)) : -1;
+                const nextStage = orderedStages.slice(currentIndex + 1).find(stage => !stage.skipped);
+                let stageId = a.stageId;
+                let skippedStages = Array.isArray(a.skippedStages) ? a.skippedStages : [];
+                let completedAt = a.completedAt;
+
+                if (skip && currentStage) {
+                  const stageIdentity = getStageIdentity(currentStage);
+                  if (!skippedStages.includes(stageIdentity)) {
+                    skippedStages = [...skippedStages, stageIdentity];
+                  }
+                  historyEntries.push({ id: `h-${timestamp}-skip`, text: `${actor} skipped ${currentStage.name}`, timestamp });
+                }
+
+                if (nextStage) {
+                  stageId = getStageIdentity(nextStage);
+                  historyEntries.push({ id: `h-${timestamp}-advance`, text: `${actor} moved to ${nextStage.name}`, timestamp });
+                } else {
+                  completedAt = completedAt || timestamp;
+                  historyEntries.push({ id: `h-${timestamp}-complete`, text: `${actor} completed the final stage`, timestamp });
+                }
+
+                return {
+                  ...a,
+                  stageId,
+                  skippedStages,
+                  completedAt,
+                  history: [...(a.history || []), ...historyEntries]
+                };
+              })
+            };
+          })
+        } : p));
+      };
+
+      const skipActivityStage = (projectId, flowId, activityId) => {
+        advanceActivityStage(projectId, flowId, activityId, { skip: true });
       };
 
       let mainContent;
@@ -646,6 +829,10 @@
             onAddAttachment={addAttachmentToActivity}
             onRemoveAttachment={removeAttachmentFromActivity}
             onMarkRead={markActivityRead}
+            onAdvanceActivityStage={(aid, options) => advanceActivityStage(selectedProject.id, selectedFlow.id, aid, options)}
+            onSkipActivityStage={(aid) => skipActivityStage(selectedProject.id, selectedFlow.id, aid)}
+            onConfigureStageConditions={(stageId, conditions) => configureStageConditions(selectedProject.id, selectedFlow.id, stageId, conditions)}
+            onToggleStageSkip={(stageId) => toggleStageSkip(selectedProject.id, selectedFlow.id, stageId)}
           />
         );
       }
@@ -896,26 +1083,60 @@
       );
     }
 
-    function ActivitiesView({ project, flow, roles, currentUser, onBack, onCreateActivity, onEditActivity, onDeleteActivity, onClaimActivity, onUnclaimActivity, onCompleteActivity, onWireActivity, onRequestRevision, onAddComment, onAddAttachment, onRemoveAttachment, onMarkRead }) {
+    function ActivitiesView({ project, flow, roles, currentUser, onBack, onCreateActivity, onEditActivity, onDeleteActivity, onClaimActivity, onUnclaimActivity, onCompleteActivity, onWireActivity, onRequestRevision, onAddComment, onAddAttachment, onRemoveAttachment, onMarkRead, onAdvanceActivityStage, onSkipActivityStage, onConfigureStageConditions, onToggleStageSkip }) {
+      const stageData = useMemo(() => {
+        const ordered = getOrderedStages(flow);
+        const map = {};
+        ordered.forEach(stage => {
+          const identity = stage.uid || getStageIdentity(stage);
+          map[identity] = stage;
+          if (stage.key) {
+            map[stage.key] = stage;
+          }
+        });
+        const fallback = ordered[0] || null;
+        return { ordered, map, fallback };
+      }, [flow]);
+
+      const getNextActiveStage = (stage) => {
+        if (!stage) return null;
+        const identity = getStageIdentity(stage);
+        const index = stageData.ordered.findIndex(item => getStageIdentity(item) === identity);
+        if (index === -1) return null;
+        return stageData.ordered.slice(index + 1).find(item => !item.skipped) || null;
+      };
+
       const activitiesWithState = useMemo(() => {
-        return flow.activities.map(activity => ({
-          ...activity,
-          state: computeActivityState(activity, flow.activities, flow.edges)
-        }));
-      }, [flow.activities, flow.edges]);
+        const fallbackId = stageData.fallback ? getStageIdentity(stageData.fallback) : null;
+        return flow.activities.map(activity => {
+          const stage = stageData.map[activity.stageId] || (fallbackId ? stageData.map[fallbackId] : null);
+          const normalizedStageId = stage ? getStageIdentity(stage) : activity.stageId || fallbackId;
+          return {
+            ...activity,
+            stageId: normalizedStageId,
+            state: computeActivityState(activity, flow.activities, flow.edges)
+          };
+        });
+      }, [flow.activities, flow.edges, stageData]);
 
       const [selectedActivityId, setSelectedActivityId] = useState(null);
 
       const groupedActivities = useMemo(() => {
         const grouped = {};
-        OPERATORS.forEach(op => {
-          grouped[op.id] = activitiesWithState.filter(activity => {
-            const role = roles.find(r => r.id === activity.roleId);
-            return role?.operatorType === op.id;
-          });
+        stageData.ordered.forEach(stage => {
+          const identity = getStageIdentity(stage);
+          grouped[identity] = [];
+        });
+        const fallbackId = stageData.fallback ? getStageIdentity(stageData.fallback) : null;
+        activitiesWithState.forEach(activity => {
+          const identity = stageData.map[activity.stageId] ? getStageIdentity(stageData.map[activity.stageId]) : fallbackId;
+          if (identity) {
+            if (!grouped[identity]) grouped[identity] = [];
+            grouped[identity].push(activity);
+          }
         });
         return grouped;
-      }, [activitiesWithState, roles]);
+      }, [activitiesWithState, stageData]);
 
       useEffect(() => {
         if (selectedActivityId && !activitiesWithState.some(a => a.id === selectedActivityId)) {
@@ -931,9 +1152,18 @@
         return selectedActivity ? roles.find(r => r.id === selectedActivity.roleId) : null;
       }, [selectedActivity, roles]);
 
-      const selectedOperator = useMemo(() => {
-        return selectedRole ? OPERATORS.find(op => op.id === selectedRole.operatorType) : null;
-      }, [selectedRole]);
+      const selectedStage = useMemo(() => {
+        if (!selectedActivity) return null;
+        return stageData.map[selectedActivity.stageId] || stageData.fallback || null;
+      }, [selectedActivity, stageData]);
+
+      const selectedNextStage = useMemo(() => {
+        if (!selectedStage) return null;
+        const identity = getStageIdentity(selectedStage);
+        const index = stageData.ordered.findIndex(stage => getStageIdentity(stage) === identity);
+        if (index === -1) return null;
+        return stageData.ordered.slice(index + 1).find(stage => !stage.skipped) || null;
+      }, [selectedStage, stageData]);
 
       const getDependencies = (activityId) => {
         const inbound = flow.edges.filter(e => e.dstId === activityId);
@@ -995,59 +1225,110 @@
               </div>
             </div>
 
-            <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
-              {OPERATORS.map(operator => (
-                <div key={operator.id} className="bg-gray-900 border border-gray-800 rounded-lg p-4">
-                  <div className="mb-4">
-                    <div className="flex items-center justify-between mb-1">
-                      <div className="flex items-center gap-2">
-                        <h3 className="font-semibold">{operator.seq}. {operator.name}</h3>
-                        <button onClick={() => onCreateActivity(operator.id)} className="p-1 rounded bg-gray-800/60 hover:bg-gray-700 transition-colors" title="Add activity">
-                          <PlusIcon className="w-3.5 h-3.5" />
-                        </button>
+            <div className="overflow-x-auto pb-4">
+              <div className="grid grid-flow-col auto-cols-[minmax(260px,1fr)] gap-4 min-h-[320px]">
+                {stageData.ordered.map((stage, index) => {
+                  const identity = getStageIdentity(stage);
+                  const stageActivities = groupedActivities[identity] || [];
+                  const assignedRole = stage.roleId ? roles.find(r => r.id === stage.roleId) : null;
+                  const stageConditions = (stage.conditions || '').trim();
+                  return (
+                    <div key={identity} className={`bg-gray-900 border ${stage.skipped ? 'border-yellow-700 border-dashed opacity-70' : 'border-gray-800'} rounded-lg p-4 min-w-[260px] flex flex-col`}>
+                      <div className="mb-4">
+                        <div className="flex items-start justify-between gap-2 mb-2">
+                          <div className="space-y-1">
+                            <div className="flex items-center gap-2">
+                              <h3 className="font-semibold text-sm">{index + 1}. {stage.name}</h3>
+                              <button
+                                onClick={() => onCreateActivity(stage.operatorKey || stage.key || stage.uid || stage.name)}
+                                className="p-1 rounded bg-gray-800/60 hover:bg-gray-700 transition-colors"
+                                title="Add activity"
+                              >
+                                <PlusIcon className="w-3.5 h-3.5" />
+                              </button>
+                            </div>
+                            <p className="text-xs text-gray-300 leading-relaxed">{stage.description}</p>
+                          </div>
+                          <span className="text-xs bg-gray-800 px-2 py-1 rounded self-start">{stageActivities.length}</span>
+                        </div>
+                        {assignedRole && (
+                          <div className="text-xs text-gray-400">Role: {assignedRole.name}</div>
+                        )}
+                        {stageConditions && (
+                          <div className="text-xs text-blue-200 bg-blue-900/30 border border-blue-800/40 rounded px-2 py-1 mt-2">
+                            Conditions: {stageConditions}
+                          </div>
+                        )}
+                        <div className="flex flex-wrap gap-2 mt-3">
+                          <button
+                            onClick={() => {
+                              if (!onConfigureStageConditions) return;
+                              const existing = stage.conditions || '';
+                              const input = window.prompt(`Set entry conditions for ${stage.name}`, existing);
+                              if (input !== null) {
+                                onConfigureStageConditions(identity, input.trim());
+                              }
+                            }}
+                            className="text-xs px-2 py-1 rounded bg-gray-800 hover:bg-gray-700 transition-colors"
+                          >
+                            Conditions
+                          </button>
+                          <button
+                            onClick={() => onToggleStageSkip && onToggleStageSkip(identity)}
+                            className={`text-xs px-2 py-1 rounded transition-colors ${stage.skipped ? 'bg-yellow-800/60 hover:bg-yellow-700/70 text-yellow-200' : 'bg-gray-800 hover:bg-gray-700'}`}
+                          >
+                            {stage.skipped ? 'Resume Stage' : 'Skip Stage'}
+                          </button>
+                        </div>
                       </div>
-                      <span className="text-xs bg-gray-800 px-2 py-1 rounded">{groupedActivities[operator.id]?.length || 0}</span>
+                      <div className="space-y-2 flex-1">
+                        {stageActivities.length === 0 ? (
+                          <p className="text-sm text-gray-500 text-center py-6">No activities</p>
+                        ) : (
+                          stageActivities.map(activity => {
+                            const role = roles.find(r => r.id === activity.roleId);
+                            const deps = getDependencies(activity.id);
+                            const activityStage = stageData.map[activity.stageId] || stageData.map[identity] || stageData.fallback;
+                            const nextStage = getNextActiveStage(activityStage);
+                            return (
+                              <ActivityCard
+                                key={activity.id}
+                                activity={activity}
+                                role={role}
+                                stage={activityStage}
+                                nextStage={nextStage}
+                                dependencies={deps}
+                                project={project}
+                                currentUser={currentUser}
+                                stageMap={stageData.map}
+                                isSelected={selectedActivityId === activity.id}
+                                onOpenDetails={openActivityDetails}
+                                onEdit={onEditActivity}
+                                onDelete={onDeleteActivity}
+                                onClaim={onClaimActivity}
+                                onUnclaim={onUnclaimActivity}
+                                onAdvanceStage={onAdvanceActivityStage}
+                                onSkipStage={onSkipActivityStage}
+                                onComplete={onCompleteActivity}
+                                onWire={onWireActivity}
+                                onRequestRevision={onRequestRevision}
+                              />
+                            );
+                          })
+                        )}
+                      </div>
                     </div>
-                    <p className="text-xs text-gray-300">{operator.desc}</p>
-                  </div>
-                  <div className="space-y-2">
-                    {groupedActivities[operator.id]?.length === 0 ? (
-                      <p className="text-sm text-gray-400 text-center py-4">No activities</p>
-                    ) : (
-                      groupedActivities[operator.id]?.map(activity => {
-                        const role = roles.find(r => r.id === activity.roleId);
-                        const deps = getDependencies(activity.id);
-                        return (
-                          <ActivityCard
-                            key={activity.id}
-                            activity={activity}
-                            role={role}
-                            operator={operator}
-                            dependencies={deps}
-                            project={project}
-                            currentUser={currentUser}
-                            isSelected={selectedActivityId === activity.id}
-                            onOpenDetails={openActivityDetails}
-                            onEdit={onEditActivity}
-                            onDelete={onDeleteActivity}
-                            onClaim={onClaimActivity}
-                            onUnclaim={onUnclaimActivity}
-                            onComplete={onCompleteActivity}
-                            onWire={onWireActivity}
-                            onRequestRevision={onRequestRevision}
-                          />
-                        );
-                      })
-                    )}
-                  </div>
-                </div>
-              ))}
+                  );
+                })}
+              </div>
             </div>
             {selectedActivity && (
               <ActivityDetailPanel
                 activity={selectedActivity}
                 role={selectedRole}
-                operator={selectedOperator}
+                stage={selectedStage}
+                nextStage={selectedNextStage}
+                stageMap={stageData.map}
                 dependencies={selectedDependencies}
                 project={project}
                 currentUser={currentUser}
@@ -1056,6 +1337,8 @@
                 onDelete={onDeleteActivity}
                 onClaim={onClaimActivity}
                 onUnclaim={onUnclaimActivity}
+                onAdvanceStage={onAdvanceActivityStage}
+                onSkipStage={onSkipActivityStage}
                 onComplete={onCompleteActivity}
                 onWire={onWireActivity}
                 onRequestRevision={onRequestRevision}
@@ -1069,10 +1352,14 @@
       );
     }
 
-    function ActivityCard({ activity, role, operator, dependencies, project, currentUser, isSelected, onOpenDetails, onEdit, onDelete, onClaim, onUnclaim, onComplete, onWire, onRequestRevision }) {
+    function ActivityCard({ activity, role, stage, nextStage, dependencies, project, currentUser, stageMap, isSelected, onOpenDetails, onEdit, onDelete, onClaim, onUnclaim, onAdvanceStage, onSkipStage, onComplete, onWire, onRequestRevision }) {
       const isMine = activity.claimedBy === currentUser;
       const canClaim = activity.state === 'ready' && !activity.claimedBy && role?.userIds.some(uid => project.users.find(u => u.id === uid)?.name === currentUser);
       const canComplete = isMine && activity.state === 'in_progress';
+      const isCompleted = activity.state === 'completed';
+      const canAdvanceStage = !isCompleted;
+      const canSkipStage = !isCompleted && !!nextStage;
+      const stageSupportsRevision = stage?.supportsRevision;
 
       const stateConfig = {
         ready: { label: 'Ready to start', color: 'bg-green-900 text-green-300' },
@@ -1086,6 +1373,9 @@
       const attachmentCount = activity.attachments?.length || 0;
       const lastRead = activity.readBy?.[currentUser] || 0;
       const hasUnread = (activity.comments || []).some(comment => !comment.system && comment.createdAt > lastRead && comment.author !== currentUser);
+      const stageName = stage?.name || 'Unassigned stage';
+      const stageBadgeClass = stage?.skipped ? 'bg-yellow-900/60 text-yellow-200' : 'bg-gray-700 text-gray-200';
+      const showRevisionButton = stageSupportsRevision && dependencies.length > 0 && !isCompleted;
 
       return (
         <div
@@ -1096,7 +1386,15 @@
           }}
         >
           <div className="flex items-start justify-between mb-2">
-            <h4 className="font-medium text-sm flex-1">{activity.title}</h4>
+            <div className="flex-1">
+              <div className="flex items-center gap-2 mb-1">
+                <span className={`text-[10px] uppercase tracking-wide px-2 py-0.5 rounded ${stageBadgeClass}`}>{stageName}</span>
+                {activity.skippedStages?.length > 0 && (
+                  <span className="text-[10px] text-yellow-300">{activity.skippedStages.length} skipped</span>
+                )}
+              </div>
+              <h4 className="font-medium text-sm">{activity.title}</h4>
+            </div>
             <div className="flex items-center gap-1 ml-2">
               <span className={`text-xs px-2 py-0.5 rounded ${config.color}`}>{config.label}</span>
               {hasUnread && <span className="w-2 h-2 rounded-full bg-blue-400" title="Unread comments" />}
@@ -1110,8 +1408,11 @@
               <div className="text-gray-400 mb-1">Waiting on:</div>
               <ul className="space-y-0.5 ml-2">
                 {dependencies.slice(0, 2).map((dep, i) => (
-                  <li key={i} className={dep.activity.completedAt ? 'line-through text-gray-500' : ''}>
-                    • {dep.activity.title} {dep.edgeType === 'loops' && '(revision)'}
+                  <li key={i} className={`flex items-center gap-2 ${dep.activity.completedAt ? 'line-through text-gray-500' : ''}`}>
+                    <span className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded bg-gray-800/80 text-[10px] text-gray-300">
+                      {stageMap?.[dep.activity.stageId]?.name || 'Stage'}
+                    </span>
+                    <span className="flex-1">{dep.activity.title} {dep.edgeType === 'loops' && '(revision)'}</span>
                   </li>
                 ))}
                 {dependencies.length > 2 && <li className="text-gray-400">+{dependencies.length - 2} more</li>}
@@ -1136,13 +1437,17 @@
             )}
             {canClaim && <button onClick={(e) => { e.stopPropagation(); onClaim(activity.id); }} className="flex-1 bg-blue-600 hover:bg-blue-700 text-xs py-1 px-2 rounded transition-colors">Claim</button>}
             {isMine && !activity.completedAt && <button onClick={(e) => { e.stopPropagation(); onUnclaim(activity.id); }} className="bg-gray-700 hover:bg-gray-600 text-xs py-1 px-2 rounded transition-colors">Unclaim</button>}
+            {canAdvanceStage && (
+              <button onClick={(e) => { e.stopPropagation(); onAdvanceStage(activity.id); }} className="bg-green-600 hover:bg-green-700 text-xs py-1 px-2 rounded transition-colors">{nextStage ? 'Advance' : 'Finish Stage'}</button>
+            )}
+            {canSkipStage && (
+              <button onClick={(e) => { e.stopPropagation(); onSkipStage(activity.id); }} className="bg-yellow-700 hover:bg-yellow-600 text-xs py-1 px-2 rounded transition-colors text-yellow-100">Skip</button>
+            )}
+            {showRevisionButton && (
+              <button onClick={(e) => { e.stopPropagation(); const lastDep = dependencies[dependencies.length - 1]; if (lastDep) onRequestRevision(activity.id, lastDep.activity.id); }} className="bg-orange-600 hover:bg-orange-700 text-xs py-1 px-2 rounded transition-colors flex items-center justify-center gap-1" title="Request revision"><RefreshIcon className="w-3 h-3" /></button>
+            )}
             {canComplete && (
-              <>
-                <button onClick={(e) => { e.stopPropagation(); onComplete(activity.id); }} className="flex-1 bg-green-600 hover:bg-green-700 text-xs py-1 px-2 rounded transition-colors">Complete</button>
-                {operator.canRequestRevision && dependencies.length > 0 && (
-                  <button onClick={(e) => { e.stopPropagation(); const lastDep = dependencies[dependencies.length - 1]; if (lastDep) onRequestRevision(activity.id, lastDep.activity.id); }} className="bg-orange-600 hover:bg-orange-700 text-xs py-1 px-2 rounded transition-colors flex items-center justify-center gap-1" title="Request revision"><RefreshIcon className="w-3 h-3" /></button>
-                )}
-              </>
+              <button onClick={(e) => { e.stopPropagation(); onComplete(activity.id); }} className="flex-1 bg-emerald-600 hover:bg-emerald-700 text-xs py-1 px-2 rounded transition-colors">Complete</button>
             )}
             {!activity.completedAt && <button onClick={(e) => { e.stopPropagation(); onWire(activity.id); }} className="bg-purple-600 hover:bg-purple-700 text-xs py-1 px-2 rounded transition-colors">Wire</button>}
           </div>


### PR DESCRIPTION
## Summary
- introduce stage metadata utilities and persistable stage configuration on flows
- replace the operator grid with a stage-ordered board that surfaces conditions, skip controls, and responsive scrolling
- enhance activity cards and the detail panel with stage-aware actions, dependency badges, and progression controls

## Testing
- Not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_b_68e6807249748332819f84e4d7ba3740